### PR TITLE
Add support for tf terraform filetype

### DIFF
--- a/autoload/neoformat/formatters/terraform.vim
+++ b/autoload/neoformat/formatters/terraform.vim
@@ -9,3 +9,16 @@ function! neoformat#formatters#terraform#terraform() abort
         \ 'stdin': 1
         \ }
 endfunction
+
+function! neoformat#formatters#tf#enabled() abort
+   return ['terraform']
+endfunction
+
+function! neoformat#formatters#tf#terraform() abort
+    return {
+        \ 'exe': 'terraform',
+        \ 'args': ['fmt', '-write', '-'],
+        \ 'stdin': 1
+        \ }
+endfunction
+


### PR DESCRIPTION
Add support for the `tf` filetype exposed by coc.vim, LSP and other tools. Traditionally, terraform filetypes have been exposed as `terraform`.